### PR TITLE
TDD to implement NFTMarket contract

### DIFF
--- a/src/ERC721/MyNFT.sol
+++ b/src/ERC721/MyNFT.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract MyNFT is ERC721 {
+    uint256 tokenId;
+
+    constructor(
+        string memory name,
+        string memory symbol
+    ) ERC721(name, symbol) {}
+
+    function mint(address to) external {
+        _mint(to, tokenId);
+        tokenId++;
+    }
+}

--- a/src/app/NFTMarket.sol
+++ b/src/app/NFTMarket.sol
@@ -10,22 +10,13 @@ import {IERC1363Receiver} from "../interfaces/IERC1363Receiver.sol";
 import {MyNFT} from "../ERC721/MyNFT.sol";
 import {ERC1363, IERC20} from "../ERC1363/ERC1363.sol";
 
-contract NFTMarket is IERC721Receiver {
-    IERC20 public payableToken;
-
-    // user => token:balance
-    struct NFTListing {
-        address seller;
-        uint256 price;
-    }
-    mapping(address nftToken => mapping(uint256 tokenId => NFTListing))
-        public userNFTListing;
-
+interface INFTMarketEvents {
     event NFTListed(
-        address indexed seller,
         address indexed nftAddress,
         uint256 indexed tokenId,
-        uint256 price
+        address seller,
+        uint256 price,
+        address token
     );
     event NFTBought(
         address indexed buyer,
@@ -38,31 +29,68 @@ contract NFTMarket is IERC721Receiver {
         address indexed nftAddress,
         uint256 indexed tokenId
     );
+}
 
-    constructor(IERC20 _payableToken) {
-        payableToken = _payableToken;
+interface INFTMarketErrors {
+    error PaymentFailed(address buyer, address seller, uint256 price);
+    error NotListedForSale(uint256 tokenId);
+    error NotAllowed(address buyer, address seller, uint256 tokenId);
+}
+
+contract NFTMarket is IERC721Receiver, INFTMarketEvents, INFTMarketErrors {
+    struct Listing {
+        address seller;
+        address token;
+        uint256 price;
     }
+    mapping(address nftToken => mapping(uint256 tokenId => Listing))
+        public userNFTListing;
+
+    constructor() {}
 
     function list(
         IERC721 nft,
         uint256 tokenId,
+        address token,
         uint256 price
-    ) public returns (bool) {
+    ) public {
         nft.safeTransferFrom(
             msg.sender,
             address(this),
             tokenId,
-            abi.encode(price)
+            abi.encode(token, price)
         );
+        // Emit an event for the listing
+        emit NFTListed(address(nft), tokenId, msg.sender, price, token);
+    }
+
+    function buy(IERC721 nft, uint256 tokenId) public returns (bool) {
+        Listing memory listing = userNFTListing[address(nft)][tokenId];
+
+        // Ensure the NFT is listed for sale
+        if (listing.seller == address(0)) {
+            revert NotListedForSale(tokenId);
+        }
+        // Ensure the NFT is listed for sale
+        if (listing.seller == msg.sender) {
+            revert NotAllowed(msg.sender, listing.seller, tokenId);
+        }
+        // Transfer the payment tokens from the buyer to the seller
+        if (
+            !IERC20(listing.token).transferFrom(
+                msg.sender,
+                listing.seller,
+                listing.price
+            )
+        ) {
+            revert PaymentFailed(msg.sender, listing.seller, listing.price);
+        }
+
+        delete userNFTListing[address(nft)][tokenId];
+        nft.transferFrom(address(this), msg.sender, tokenId);
 
         return true;
     }
-
-    function buy(
-        IERC721 nft,
-        uint256 tokenId,
-        IERC20 erc20
-    ) public returns (bool) {}
 
     function onERC721Received(
         address /*operator*/,
@@ -70,20 +98,25 @@ contract NFTMarket is IERC721Receiver {
         uint256 tokenId,
         bytes calldata data
     ) external override returns (bytes4) {
-        address seller = from;
-        uint256 price = abi.decode(data, (uint256));
         address nft = msg.sender;
+        require(nft.code.length > 0, "Only contract");
+        (address token, uint256 price) = abi.decode(data, (address, uint256));
+        // if (price == 0 || token == address(0)) {
+        //     return this.onERC721Received.selector;
+        // }
+        address seller = from;
 
-        userNFTListing[nft][tokenId] = NFTListing(seller, price);
+        userNFTListing[nft][tokenId] = Listing(seller, token, price);
         return this.onERC721Received.selector;
     }
 
     function getTokenSellInfo(
         uint256 tokenId,
         IERC721 erc721
-    ) public view returns (address, uint256) {
+    ) public view returns (address, address, uint256) {
         return (
             userNFTListing[address(erc721)][tokenId].seller,
+            userNFTListing[address(erc721)][tokenId].token,
             userNFTListing[address(erc721)][tokenId].price
         );
     }

--- a/src/app/NFTMarket.sol
+++ b/src/app/NFTMarket.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+import {IERC1363} from "../interfaces/IERC1363.sol";
+import {IERC1363Receiver} from "../interfaces/IERC1363Receiver.sol";
+import {MyNFT} from "../ERC721/MyNFT.sol";
+import {ERC1363, IERC20} from "../ERC1363/ERC1363.sol";
+
+contract NFTMarket is IERC721Receiver {
+    IERC20 public payableToken;
+
+    // user => token:balance
+    struct NFTListing {
+        address seller;
+        uint256 price;
+    }
+    mapping(address nftToken => mapping(uint256 tokenId => NFTListing))
+        public userNFTListing;
+
+    event NFTListed(
+        address indexed seller,
+        address indexed nftAddress,
+        uint256 indexed tokenId,
+        uint256 price
+    );
+    event NFTBought(
+        address indexed buyer,
+        address indexed nftAddress,
+        uint256 indexed tokenId,
+        uint256 price
+    );
+    event NFTDelisted(
+        address indexed seller,
+        address indexed nftAddress,
+        uint256 indexed tokenId
+    );
+
+    constructor(IERC20 _payableToken) {
+        payableToken = _payableToken;
+    }
+
+    function list(
+        IERC721 nft,
+        uint256 tokenId,
+        uint256 price
+    ) public returns (bool) {
+        nft.safeTransferFrom(
+            msg.sender,
+            address(this),
+            tokenId,
+            abi.encode(price)
+        );
+
+        return true;
+    }
+
+    function buy(
+        IERC721 nft,
+        uint256 tokenId,
+        IERC20 erc20
+    ) public returns (bool) {}
+
+    function onERC721Received(
+        address /*operator*/,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    ) external override returns (bytes4) {
+        address seller = from;
+        uint256 price = abi.decode(data, (uint256));
+        address nft = msg.sender;
+
+        userNFTListing[nft][tokenId] = NFTListing(seller, price);
+        return this.onERC721Received.selector;
+    }
+
+    function getTokenSellInfo(
+        uint256 tokenId,
+        IERC721 erc721
+    ) public view returns (address, uint256) {
+        return (
+            userNFTListing[address(erc721)][tokenId].seller,
+            userNFTListing[address(erc721)][tokenId].price
+        );
+    }
+}

--- a/test/NFTMarket.t.sol
+++ b/test/NFTMarket.t.sol
@@ -3,22 +3,31 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20Errors, IERC721Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 
 import {IERC1363} from "../src/interfaces/IERC1363.sol";
-import {NFTMarket} from "../src/app/NFTMarket.sol";
+import {NFTMarket, INFTMarketEvents, INFTMarketErrors} from "../src/app/NFTMarket.sol";
 import {MyNFT} from "../src/ERC721/MyNFT.sol";
 import {ERC1363, ERC20} from "../src/ERC1363/ERC1363.sol";
 
-contract MockERC1363 is ERC1363 {
+contract MockERC20 is ERC20 {
     constructor(string memory name, string memory symbol) ERC20(name, symbol) {
         _mint(msg.sender, 1000 * 10 ** 18);
     }
 }
 
-contract NFTMarketTest is Test {
+contract NFTMarketTest is
+    Test,
+    INFTMarketEvents,
+    INFTMarketErrors,
+    IERC20Errors,
+    IERC721Errors
+{
     MyNFT myNFT1;
     MyNFT myNFT2;
-    MockERC1363 tokenA;
+    MockERC20 tokenA;
+    MockERC20 tokenB;
     NFTMarket nftMarket;
     uint256 tokenId1;
     uint256 tokenId2;
@@ -34,8 +43,9 @@ contract NFTMarketTest is Test {
     function setUp() public {
         myNFT1 = new MyNFT("MuMu", "MMT");
         myNFT2 = new MyNFT("Taylor", "TTT");
-        tokenA = new MockERC1363("TokenA", "TA");
-        nftMarket = new NFTMarket(tokenA);
+        tokenA = new MockERC20("TokenA", "TA");
+        tokenB = new MockERC20("TokenA", "TB");
+        nftMarket = new NFTMarket();
 
         owner = address(this);
         user1 = address(0x1);
@@ -47,61 +57,186 @@ contract NFTMarketTest is Test {
 
         tokenA.transfer(user1, 10e18);
         tokenA.transfer(user2, 10e18);
+
+        tokenB.transfer(user2, 10e18);
+        tokenB.transfer(user1, 10e18);
     }
 
     function test_list_listing_info_from_ERC721_safeTransferFrom() public {
+        listNFT();
+    }
+
+    function test_buy_nft_with_token_transfer_directly() public {
+        listNFT();
+        uint256 user2NFTBalanceBeforeBuy = myNFT1.balanceOf(user2);
+        uint256 user1BalanceBeforeNFTSold = tokenB.balanceOf(user1);
+        uint256 user2BalanceBeforeNFTSold = tokenB.balanceOf(user2);
+
+        vm.startPrank(user2);
+        tokenB.approve(address(nftMarket), tokenId1Price);
+        nftMarket.buy(myNFT1, tokenId1);
+        vm.stopPrank();
+
+        // expect the nftMarket tranfer the token to the user1 directly
+        assertEq(
+            tokenB.balanceOf(user1),
+            user1BalanceBeforeNFTSold + tokenId1Price
+        );
+        assertEq(
+            tokenB.balanceOf(user2),
+            user2BalanceBeforeNFTSold - tokenId1Price
+        );
+
+        // transfert the nft to the user2
+        assertEq(myNFT1.balanceOf(user1), 0);
+        assertEq(myNFT1.balanceOf(user2), user2NFTBalanceBeforeBuy + 1);
+        assertEq(myNFT1.ownerOf(tokenId1), user2);
+
+        // ensure the nftContract.safeTransferFrom callback not listing the nft
+        (address seller1Sold, address sellToken, uint256 price1Sold) = nftMarket
+            .getTokenSellInfo(tokenId1, myNFT1);
+        assertEq(seller1Sold, address(0));
+        assertEq(sellToken, address(0));
+        assertEq(price1Sold, 0);
+    }
+
+    function test_not_allow_buy_self_nft() public {
         vm.startPrank(user1);
         myNFT1.approve(address(nftMarket), tokenId1);
-        nftMarket.list(myNFT1, tokenId1, tokenId1Price);
-        (address seller1, uint256 price1) = nftMarket.getTokenSellInfo(
-            tokenId1,
-            myNFT1
+        nftMarket.list(myNFT1, tokenId1, address(tokenB), tokenId1Price);
+
+        (address seller, , ) = nftMarket.getTokenSellInfo(tokenId1, myNFT1);
+
+        tokenB.approve(address(nftMarket), tokenId1Price);
+        vm.expectRevert(
+            abi.encodeWithSelector(NotAllowed.selector, user1, seller, tokenId1)
         );
+        nftMarket.buy(myNFT1, tokenId1);
+        vm.stopPrank();
+    }
+
+    function testBuyWithIncorrectPaymentFailure() public {
+        vm.startPrank(user1);
+        myNFT1.approve(address(nftMarket), tokenId1);
+        nftMarket.list(myNFT1, tokenId1, address(tokenA), tokenId1Price);
+        vm.stopPrank();
+
+        vm.startPrank(user2);
+        uint256 incorrectPrice = tokenId1Price - 1;
+        tokenA.approve(address(nftMarket), incorrectPrice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC20InsufficientAllowance.selector,
+                address(nftMarket),
+                incorrectPrice,
+                tokenId1Price
+            )
+        );
+        nftMarket.buy(myNFT1, tokenId1);
+        vm.stopPrank();
+    }
+
+    function test_not_allow_buy_sold_nft() public {
+        vm.startPrank(user1);
+        myNFT1.approve(address(nftMarket), tokenId1);
+        nftMarket.list(myNFT1, tokenId1, address(tokenB), tokenId1Price);
+        vm.stopPrank();
+
+        vm.startPrank(user2);
+        tokenB.approve(address(nftMarket), tokenId1Price);
+        nftMarket.buy(myNFT1, tokenId1);
+        vm.expectRevert(
+            abi.encodeWithSelector(NotListedForSale.selector, tokenId1)
+        );
+        nftMarket.buy(myNFT1, tokenId1);
+        vm.stopPrank();
+    }
+
+    function testListFailure() public {
+        vm.startPrank(user2);
+        vm.expectRevert(
+            abi.encodeWithSelector(ERC721InvalidApprover.selector, user2)
+        );
+        myNFT1.approve(address(nftMarket), tokenId1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC721InsufficientApproval.selector,
+                address(nftMarket),
+                tokenId1
+            )
+        );
+        nftMarket.list(myNFT1, tokenId1, address(tokenA), tokenId1Price);
+        vm.stopPrank();
+    }
+
+    function testInvariant_TokenBalance() public {
+        uint256 nftMarketBalanceA = tokenA.balanceOf(address(nftMarket));
+        uint256 nftMarketBalanceB = tokenB.balanceOf(address(nftMarket));
+        assertEq(nftMarketBalanceA, 0);
+        assertEq(nftMarketBalanceB, 0);
+    }
+
+    function testFuzzListAndBuy(uint256 price) public {
+        vm.assume(price > 0.01 ether && price < 10000 ether);
+
+        vm.startPrank(user1);
+        myNFT1.approve(address(nftMarket), tokenId1);
+        nftMarket.list(myNFT1, tokenId1, address(tokenA), price);
+        vm.stopPrank();
+
+        // ensure that buyer balance always >= price
+        uint256 user2Balance = tokenA.balanceOf(user2);
+        vm.assume(user2Balance >= price);
+
+        vm.startPrank(user2);
+        uint256 user2BalanceBefore = tokenA.balanceOf(user2);
+        uint256 user1BalanceBefore = tokenA.balanceOf(user1);
+        tokenA.approve(address(nftMarket), price);
+        nftMarket.buy(myNFT1, tokenId1);
+        vm.stopPrank();
+
+        assertEq(tokenA.balanceOf(user1), user1BalanceBefore + price);
+        assertEq(tokenA.balanceOf(user2), user2BalanceBefore - price);
+        assertEq(myNFT1.ownerOf(tokenId1), user2);
+    }
+
+    function testOnERC721Received() public {
+        bytes memory data = abi.encode(address(tokenA), tokenId1Price);
+        vm.startPrank(user1);
+        myNFT1.safeTransferFrom(user1, address(nftMarket), tokenId1, data);
+        vm.stopPrank();
+
+        (address seller, address token, uint256 price) = nftMarket
+            .getTokenSellInfo(tokenId1, myNFT1);
+        assertEq(seller, user1);
+        assertEq(token, address(tokenA));
+        assertEq(price, tokenId1Price);
+    }
+
+    function listNFT() internal {
+        vm.startPrank(user1);
+        myNFT1.approve(address(nftMarket), tokenId1);
+        vm.expectEmit(true, true, false, true);
+        emit NFTListed(
+            address(myNFT1),
+            tokenId1,
+            user1,
+            tokenId1Price,
+            address(tokenB)
+        );
+        nftMarket.list(myNFT1, tokenId1, address(tokenB), tokenId1Price);
+        (address seller, address sellToken, uint256 price) = nftMarket
+            .getTokenSellInfo(tokenId1, myNFT1);
         vm.stopPrank();
 
         // nftmarket.onTransferReceived should list the transfered nft to the listing
-        assertEq(seller1, user1);
-        assertEq(price1, tokenId1Price);
+        assertEq(seller, user1);
+        assertEq(price, tokenId1Price);
+        assertEq(address(sellToken), address(tokenB));
 
         // nft transfered to the nftmarket after nftContract.safeTransferFrom
         assertEq(myNFT1.ownerOf(tokenId1), address(nftMarket));
         // nft token approval cleared for the nftmarket after nftContract.safeTransferFrom
         assertEq(myNFT1.getApproved(tokenId1), address(0x0));
-    }
-
-    function test_buy_nft_with_token_transfer_directly() public {
-        vm.startPrank(user1);
-        myNFT1.approve(address(nftMarket), tokenId1);
-        nftMarket.list(myNFT1, tokenId1, tokenId1Price);
-        (address seller1, uint256 price1) = nftMarket.getTokenSellInfo(
-            tokenId1,
-            myNFT1
-        );
-        assertEq(seller1, user1);
-        assertEq(price1, tokenId1Price);
-        vm.stopPrank();
-
-        uint256 user1BalanceBeforeNFTSold = tokenA.balanceOf(user1);
-        vm.startPrank(user2);
-        nftMarket.buy(myNFT1, tokenId1, tokenA);
-        vm.stopPrank();
-
-        // expect the nftMarket tranfer the token to the user1 directly
-        assertEq(
-            tokenA.balanceOf(user1),
-            user1BalanceBeforeNFTSold + tokenId1Price
-        );
-
-        // transfert the nft to the user2
-        assertEq(myNFT1.balanceOf(user1), 0);
-        assertEq(myNFT1.balanceOf(user2), 1);
-        assertEq(myNFT1.ownerOf(tokenId1), user2);
-
-        (address seller1Sold, uint256 price1Sold) = nftMarket.getTokenSellInfo(
-            tokenId1,
-            myNFT1
-        );
-        assertEq(seller1Sold, address(0x0));
-        assertEq(price1Sold, 0);
     }
 }

--- a/test/NFTMarket.t.sol
+++ b/test/NFTMarket.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+import {IERC1363} from "../src/interfaces/IERC1363.sol";
+import {NFTMarket} from "../src/app/NFTMarket.sol";
+import {MyNFT} from "../src/ERC721/MyNFT.sol";
+import {ERC1363, ERC20} from "../src/ERC1363/ERC1363.sol";
+
+contract MockERC1363 is ERC1363 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {
+        _mint(msg.sender, 1000 * 10 ** 18);
+    }
+}
+
+contract NFTMarketTest is Test {
+    MyNFT myNFT1;
+    MyNFT myNFT2;
+    MockERC1363 tokenA;
+    NFTMarket nftMarket;
+    uint256 tokenId1;
+    uint256 tokenId2;
+    uint256 tokenId1Price = 1e18;
+    uint256 tokenId2Price = 2e18;
+
+    address owner;
+    address user1;
+    address user2;
+
+    uint256 erc20Unit = 10 ** 18;
+
+    function setUp() public {
+        myNFT1 = new MyNFT("MuMu", "MMT");
+        myNFT2 = new MyNFT("Taylor", "TTT");
+        tokenA = new MockERC1363("TokenA", "TA");
+        nftMarket = new NFTMarket(tokenA);
+
+        owner = address(this);
+        user1 = address(0x1);
+        user2 = address(0x2);
+        myNFT1.mint(user1);
+        tokenId1 = 0;
+        myNFT1.mint(user2);
+        tokenId2 = 0;
+
+        tokenA.transfer(user1, 10e18);
+        tokenA.transfer(user2, 10e18);
+    }
+
+    function test_list_listing_info_from_ERC721_safeTransferFrom() public {
+        vm.startPrank(user1);
+        myNFT1.approve(address(nftMarket), tokenId1);
+        nftMarket.list(myNFT1, tokenId1, tokenId1Price);
+        (address seller1, uint256 price1) = nftMarket.getTokenSellInfo(
+            tokenId1,
+            myNFT1
+        );
+        vm.stopPrank();
+
+        // nftmarket.onTransferReceived should list the transfered nft to the listing
+        assertEq(seller1, user1);
+        assertEq(price1, tokenId1Price);
+
+        // nft transfered to the nftmarket after nftContract.safeTransferFrom
+        assertEq(myNFT1.ownerOf(tokenId1), address(nftMarket));
+        // nft token approval cleared for the nftmarket after nftContract.safeTransferFrom
+        assertEq(myNFT1.getApproved(tokenId1), address(0x0));
+    }
+
+    function test_buy_nft_with_token_transfer_directly() public {
+        vm.startPrank(user1);
+        myNFT1.approve(address(nftMarket), tokenId1);
+        nftMarket.list(myNFT1, tokenId1, tokenId1Price);
+        (address seller1, uint256 price1) = nftMarket.getTokenSellInfo(
+            tokenId1,
+            myNFT1
+        );
+        assertEq(seller1, user1);
+        assertEq(price1, tokenId1Price);
+        vm.stopPrank();
+
+        uint256 user1BalanceBeforeNFTSold = tokenA.balanceOf(user1);
+        vm.startPrank(user2);
+        nftMarket.buy(myNFT1, tokenId1, tokenA);
+        vm.stopPrank();
+
+        // expect the nftMarket tranfer the token to the user1 directly
+        assertEq(
+            tokenA.balanceOf(user1),
+            user1BalanceBeforeNFTSold + tokenId1Price
+        );
+
+        // transfert the nft to the user2
+        assertEq(myNFT1.balanceOf(user1), 0);
+        assertEq(myNFT1.balanceOf(user2), 1);
+        assertEq(myNFT1.ownerOf(tokenId1), user2);
+
+        (address seller1Sold, uint256 price1Sold) = nftMarket.getTokenSellInfo(
+            tokenId1,
+            myNFT1
+        );
+        assertEq(seller1Sold, address(0x0));
+        assertEq(price1Sold, 0);
+    }
+}

--- a/test/SimpleBank.t.sol
+++ b/test/SimpleBank.t.sol
@@ -6,6 +6,8 @@ import "forge-std/Test.sol";
 contract Bank {
     mapping(address => uint) public balanceOf;
 
+    error MyError(uint256 a);
+
     event Deposit(address indexed user, uint amount);
 
     function depositETH() external payable {
@@ -18,6 +20,7 @@ contract Bank {
 contract BankTest is Test {
     Bank bank;
     address user;
+    event Deposit(address indexed user, uint amount);
 
     function setUp() public {
         bank = new Bank();
@@ -34,7 +37,8 @@ contract BankTest is Test {
 
         // Expect the Deposit event
         vm.expectEmit(true, false, false, true);
-        emit Bank.Deposit(address(user), amount);
+
+        emit Deposit(address(user), amount);
         bank.depositETH{value: amount}();
 
         // Verify the balance


### PR DESCRIPTION
编写 NFTMarket 合约：
支持设定任意ERC20价格来上架NFT
支持支付ERC20购买指定的NFT

测试内容：
上架NFT：测试上架成功和失败情况，要求断言错误信息和上架事件。
购买NFT：测试购买成功、自己购买自己的NFT、NFT被重复购买、支付Token过多或者过少情况，要求断言错误信息和购买事件。
模糊测试：测试随机使用 0.01-10000 Token价格上架NFT，并随机使用任意Address购买NFT
「可选」不可变测试：测试无论如何买卖，NFTMarket合约中都不可能有 Token 持仓